### PR TITLE
json server 응답 포매팅

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lint": "eslint src/**/*.{ts,tsx}",
     "lint:fix": "eslint --fix 'src/**/*.{js,jsx,ts,tsx}'",
     "format": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,md}' --config ./.prettierrc",
-    "server":"json-server --watch ./public/database/schedules.json --port 8000"
+    "server": "node ./public/database/server.js"
   },
   "eslintConfig": {
     "extends": [

--- a/public/database/server.js
+++ b/public/database/server.js
@@ -1,0 +1,44 @@
+const jsonServer = require('json-server');
+const server = jsonServer.create();
+const router = jsonServer.router('./public/database/schedules.json');
+const middlewares = jsonServer.defaults();
+
+server.use(middlewares);
+
+server.use(jsonServer.bodyParser);
+
+router.render = (req, res) => {
+  console.log(Array.isArray(res.locals.data), res.locals.data);
+  if (req.method === 'GET' && Array.isArray(res.locals.data)) {
+    console.log(req.originalUrl);
+    const data = res.locals.data;
+    const integratedByWeekday = data.reduce(
+      (accum, cur) => {
+        accum[cur.weekday].push(cur);
+        return accum;
+      },
+      {
+        monday: [],
+        tuesday: [],
+        wednesday: [],
+        thursday: [],
+        friday: [],
+        saturday: [],
+        sunday: [],
+      },
+    );
+
+    res.jsonp({
+      schedules: integratedByWeekday,
+    });
+  } else {
+    res.jsonp({
+      schedules: res.locals.data,
+    });
+  }
+};
+
+server.use(router);
+server.listen(8000, () => {
+  console.log('JSON Server is running');
+});

--- a/public/database/server.js
+++ b/public/database/server.js
@@ -8,9 +8,7 @@ server.use(middlewares);
 server.use(jsonServer.bodyParser);
 
 router.render = (req, res) => {
-  console.log(Array.isArray(res.locals.data), res.locals.data);
   if (req.method === 'GET' && Array.isArray(res.locals.data)) {
-    console.log(req.originalUrl);
     const data = res.locals.data;
     const integratedByWeekday = data.reduce(
       (accum, cur) => {


### PR DESCRIPTION
* GET요청시 응답이 아래와 같이 요일별로 묶여서 오도록 수정했습니다.
<img width="729" alt="image" src="https://user-images.githubusercontent.com/49019236/181430128-b80cb628-0c79-4901-9fb0-bc64141a53cc.png">
* PUT/DELETE시 기존 사용법과 같이 localhost:8000/schedules/id 형식으로 url맞춰서 보내주시면 됩니다.