### PR TITLE
시간표에서 수업 삭제하기 기능 구현

### DIFF
--- a/src/components/cCard.tsx
+++ b/src/components/cCard.tsx
@@ -5,16 +5,16 @@ import styled from 'styled-components';
 
 interface cCardProps {
   lecture: ServerSideSchedule;
-  onClick: () => void;
+  onClick: (event: React.SyntheticEvent, id: number) => void;
 }
 
 function cCard({ lecture, onClick }: cCardProps) {
-  const { start, end } = lecture;
+  const { id, start, end } = lecture;
   return (
     <Card>
       <Left>{`${start} ~ ${end}`}</Left>
       <Right>
-        <RemoveButton onClick={onClick}>
+        <RemoveButton onClick={(event) => onClick(event, id)}>
           <ClearIcon sx={{ fontSize: 10 }} />
         </RemoveButton>
       </Right>

--- a/src/components/cCard.tsx
+++ b/src/components/cCard.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 interface cCardProps {
   lecture: ServerSideSchedule;
-  onClick: (event: React.SyntheticEvent, id: number) => void;
+  onClick: (id: number) => void;
 }
 
 function cCard({ lecture, onClick }: cCardProps) {
@@ -14,7 +14,7 @@ function cCard({ lecture, onClick }: cCardProps) {
     <Card>
       <Left>{`${start} ~ ${end}`}</Left>
       <Right>
-        <RemoveButton onClick={(event) => onClick(event, id)}>
+        <RemoveButton onClick={() => onClick(id)}>
           <ClearIcon sx={{ fontSize: 10 }} />
         </RemoveButton>
       </Right>

--- a/src/components/timetable/DeleteDialog.tsx
+++ b/src/components/timetable/DeleteDialog.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Dialog, DialogTitle, DialogActions, Button } from '@mui/material';
+
+interface DeleteDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+function DeleteDialog({ open, onClose, onConfirm }: DeleteDialogProps) {
+  const noticeText = '수업을 삭제 하시겠습니까?';
+
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>{noticeText}</DialogTitle>
+      <DialogActions>
+        <Button variant='outlined' onClick={onClose}>
+          취소
+        </Button>
+        <Button variant='outlined' onClick={onConfirm}>
+          삭제
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default DeleteDialog;

--- a/src/components/timetable/index.tsx
+++ b/src/components/timetable/index.tsx
@@ -8,10 +8,16 @@ interface TimetableProps {
 }
 
 function Timetable({ schedules }: TimetableProps) {
-  const [, setOpenModal] = React.useState(false);
+  const handleDeleteTime = (event: React.SyntheticEvent, id: number) => {
+    if (confirm('수업을 삭제 하시겠습니까?')) {
+      deleteTime(id);
+    }
+  };
 
-  const handleOpenModal = () => {
-    setOpenModal(true);
+  const deleteTime = (id: number) => {
+    fetch(`http://localhost:8000/schedules/${id}`, { method: 'DELETE' }).catch((error) => {
+      console.error(error);
+    });
   };
 
   return (
@@ -22,7 +28,7 @@ function Timetable({ schedules }: TimetableProps) {
           <Divider />
           <Schedule>
             {lectures.map((lecture: ServerSideSchedule) => (
-              <CCard key={lecture.id} lecture={lecture} onClick={handleOpenModal}></CCard>
+              <CCard key={lecture.id} lecture={lecture} onClick={handleDeleteTime}></CCard>
             ))}
           </Schedule>
         </Day>

--- a/src/components/timetable/index.tsx
+++ b/src/components/timetable/index.tsx
@@ -2,16 +2,23 @@ import React from 'react';
 import CCard from '../cCard';
 import styled from 'styled-components';
 import { ServerSideScheduleWrapper, ServerSideSchedule } from '../../types';
+import DeleteDialog from './DeleteDialog';
 
 interface TimetableProps {
   schedules: ServerSideScheduleWrapper | [];
 }
 
 function Timetable({ schedules }: TimetableProps) {
-  const handleDeleteTime = (event: React.SyntheticEvent, id: number) => {
-    if (confirm('수업을 삭제 하시겠습니까?')) {
-      deleteTime(id);
-    }
+  const [openDialog, setOpenDialog] = React.useState(false);
+  const [selectedLectureId, setSelectedLectureId] = React.useState(-1);
+
+  const handleDeleteClick = (id: number) => {
+    setSelectedLectureId(id);
+    setOpenDialog(true);
+  };
+
+  const handleDeleteTime = () => {
+    deleteTime(selectedLectureId);
   };
 
   const deleteTime = (id: number) => {
@@ -28,11 +35,16 @@ function Timetable({ schedules }: TimetableProps) {
           <Divider />
           <Schedule>
             {lectures.map((lecture: ServerSideSchedule) => (
-              <CCard key={lecture.id} lecture={lecture} onClick={handleDeleteTime}></CCard>
+              <CCard key={lecture.id} lecture={lecture} onClick={handleDeleteClick}></CCard>
             ))}
           </Schedule>
         </Day>
       ))}
+      <DeleteDialog
+        open={openDialog}
+        onClose={() => setOpenDialog(false)}
+        onConfirm={handleDeleteTime}
+      />
     </Container>
   );
 }


### PR DESCRIPTION
# 개요

- 시간표 내부의 x 버튼을 누르면 삭제 알림을 표시한다
- 삭제 알림에서 확인을 누르면 수업을 삭제한다

## 커스텀 다이얼로그가 필요했던 이유

- confirm 기능은 브라우저가 제어하는 영역이라서 위치 조정과 크로스 플랫폼 문제가 있었다
- 위치를 조정하고 다양한 브라우저에서 일관성 있는 UX 제공을 위해 커스텀 다이얼로그를 작성했다