### PR TITLE
수업 추가 페이지 리피트 버튼 관련 버그 해결

### DIFF
--- a/src/pages/add/RepeatButton.tsx
+++ b/src/pages/add/RepeatButton.tsx
@@ -11,7 +11,13 @@ interface RepeatButtonProps {
 function RepeatButton({ week, handleChange, checked, isUnavailable }: RepeatButtonProps) {
   return (
     <span key={week}>
-      <Checkbox id={week} value={week.toLowerCase()} checked={checked} onChange={handleChange} />
+      <Checkbox
+        id={week}
+        value={week.toLowerCase()}
+        checked={checked}
+        onChange={handleChange}
+        disabled={isUnavailable}
+      />
       <CheckboxLabel htmlFor={week}>{week}</CheckboxLabel>
     </span>
   );

--- a/src/pages/add/StartTimeSelector.tsx
+++ b/src/pages/add/StartTimeSelector.tsx
@@ -32,11 +32,15 @@ const MenuProps = {
 
 interface IStartTimeSelector {
   handleTimeChange: (startTimeString12: string, endTimeString12: string) => void;
+  resetRepeatButton: () => void;
 }
 
 const MINUTE_15_INDEX = 3;
 
-export default function StartTimeSelector({ handleTimeChange }: IStartTimeSelector) {
+export default function StartTimeSelector({
+  handleTimeChange,
+  resetRepeatButton,
+}: IStartTimeSelector) {
   const defaultHourIndex = +getHourIndexItem('0');
   const defaultMinuteIndex = +getMinuteIndexItem('0');
   const defaultTimeType = getTimeTypeItem(AM) as typeTimeType;
@@ -51,10 +55,12 @@ export default function StartTimeSelector({ handleTimeChange }: IStartTimeSelect
     const value = event.target.value;
     setHourIndex(+value);
     clearMinuteIndex(timeType, +value);
+    resetRepeatButton();
   };
   const handleMinuteChange = (event: SelectChangeEvent) => {
     const value = event.target.value;
     setMinuteIndex(+value);
+    resetRepeatButton();
   };
   const handleTypeChange = (event: React.MouseEvent<HTMLElement>, newAlignment: string) => {
     if (newAlignment === null) return;
@@ -62,6 +68,7 @@ export default function StartTimeSelector({ handleTimeChange }: IStartTimeSelect
     const type = newAlignment as typeTimeType;
     setTimeType(type);
     clearMinuteIndex(type, hourIndex);
+    resetRepeatButton();
   };
 
   useEffect(() => {

--- a/src/pages/add/index.tsx
+++ b/src/pages/add/index.tsx
@@ -21,14 +21,14 @@ const DEFAULT_TIME: scheduleTime = {
 export default function Add() {
   const { mutateAsync } = useAddSchedule();
   const [schedule, setSchedule] = useState<scheduleTime>(DEFAULT_TIME);
-  const [selectedWeekDays, setSelectedWeekDays] = useState<Set<string>>(new Set<string>());
+  const [selectedWeekDays, setSelectedWeekDays] = useState<Set<Weekdays>>(new Set());
   const navigate = useNavigate();
   const goMain = () => {
     navigate('/');
   };
 
   const resetRepeatButton = () => {
-    setSelectedWeekDays(new Set<string>());
+    setSelectedWeekDays(new Set());
   };
 
   useEffect(() => {
@@ -54,8 +54,8 @@ export default function Add() {
   };
 
   const handleRepeatButtonClick: ChangeEventHandler<HTMLInputElement> = (event) => {
-    const week = event.target.value.toLowerCase();
-    const prevSelectedDays = new Set<string>(selectedWeekDays);
+    const week = event.target.value.toLowerCase() as Weekdays;
+    const prevSelectedDays = new Set<Weekdays>(selectedWeekDays);
     if (selectedWeekDays.has(week)) {
       prevSelectedDays.delete(week);
     } else {
@@ -65,7 +65,7 @@ export default function Add() {
     setWeekdayItem(prevSelectedDays);
   };
 
-  const handleSaveSchedules = async (time: scheduleTime, weekdays: Set<string>) => {
+  const handleSaveSchedules = async (time: scheduleTime, weekdays: Set<Weekdays>) => {
     if (selectedWeekDays.size === 0) {
       alert('추가할 요일을 선택해주세요.');
       return;
@@ -74,12 +74,7 @@ export default function Add() {
     const startTime = objectToString24(time.start);
     const endTime = objectToString24(time.end);
     for (const weekday of weekdays) {
-      const scheduleList: string[] = [];
-      scheduleList.push(weekday, startTime, endTime);
-      const weekValue = scheduleList[0];
-      const startValue = scheduleList[1];
-      const endValue = scheduleList[2];
-      await mutateAsync({ weekday: weekValue, start: startValue, end: endValue });
+      await mutateAsync({ weekday, start: startTime, end: endTime });
     }
     alert('시간표가 추가되었습니다.');
     goMain();
@@ -99,7 +94,7 @@ export default function Add() {
               <RepeatButton
                 key={week}
                 week={week}
-                checked={selectedWeekDays.has(week.toLowerCase())}
+                checked={selectedWeekDays.has(week.toLowerCase() as Weekdays)}
                 handleChange={handleRepeatButtonClick}
                 isUnavailable={unavailableDays.includes(week.toLowerCase() as Weekdays)}
               />

--- a/src/pages/add/index.tsx
+++ b/src/pages/add/index.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import StartTimeSelector from './StartTimeSelector';
 import { checkSchedules, objectToString24, string12ToObject } from '../../utils/dateTimeHelper';
 import RepeatButton from './RepeatButton';
-import { getWeekdayItem, setWeekdayItem } from '../../utils/storage';
+import { clearStorage, getWeekdayItem, setWeekdayItem } from '../../utils/storage';
 import { useAddSchedule, useGetSchedules } from '../../queries/schedule';
 import { Weekdays } from '../../types';
 
@@ -78,6 +78,7 @@ export default function Add() {
       await mutateAsync({ weekday, start: startTime, end: endTime });
     }
     alert('시간표가 추가되었습니다.');
+    clearStorage();
     goMain();
   };
   return (

--- a/src/pages/add/index.tsx
+++ b/src/pages/add/index.tsx
@@ -29,6 +29,7 @@ export default function Add() {
 
   const resetRepeatButton = () => {
     setSelectedWeekDays(new Set());
+    setWeekdayItem(new Set());
   };
 
   useEffect(() => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,7 +12,7 @@ export type Weekdays =
 
 export interface ISchedule {
   id?: number;
-  weekday: string;
+  weekday: Weekdays;
   start: string;
   end: string;
 }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -51,3 +51,11 @@ function setStorageItem(key: string, value: string) {
     console.log(e);
   }
 }
+
+export function clearStorage() {
+  try {
+    localStorage.clear();
+  } catch (e) {
+    console.log(e);
+  }
+}


### PR DESCRIPTION
# 개요

- [x]  스테이트 리셋 될 때 localstorage도 리셋
- [x] 메인화면으로 갔다오면 데이터 유지되지 않도록 함
- [x]  요일 선택하는 state 타입을 WeekDays로 해서 타입을 좁힘

# 해결방법
**1. 스테이트 리셋 될 때 로컬스토리지도 리셋**
 - index.ts에서 schedule이 바뀌면 reset되게 하려고 했으나 첫 마운트시 shedule이 3번 변해서 reset이 3번 되면서 문제가 발생함.(사실 strict mode제거 하면 이 때도 동작하기는 함)
 - 맨 처음 마운트 됐을 때 로컬 스토리지의 정보를 가져와 저장돼있는 정보를 스테이트에 저장하지만, 이후 reset이 몇번더 호출되면서 결국 초기화되는 문제점이 있었음.
 - 여러번 호출되지 않게 하기 위해 StartTimeSelect.tsx에서 시간/분/타입 change 핸들러에서 reset함수를 호출하게 함.

**2. 메인화면으로 갔다오면 데이터 유지되지 않도록 함**
- 저장버튼 누르고 요청 성공했을 때 로컬스토리지를 비워줌

**3. 요일 선택하는 state 타입을 WeekDays로 해서 타입을 좁힘**
- 기존 string타입에서 WeekDays타입으로 변경