### PR TITLE
post, delete 요청 후 schedules데이터 업데이트 안되는 버그 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start & npm run server",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/src/queries/schedule.ts
+++ b/src/queries/schedule.ts
@@ -1,18 +1,34 @@
 import httpClient from '../http';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ISchedule, ServerSideScheduleWrapper } from '../types';
 
 export function useGetSchedules() {
   const query = '';
-  return useQuery(['schedules'], () =>
-    httpClient.get<ServerSideScheduleWrapper>(`schedules${query}`),
+  return useQuery(
+    ['schedules'],
+    () => httpClient.get<ServerSideScheduleWrapper>(`schedules${query}`),
+    {
+      staleTime: 1000 * 60,
+    },
   );
 }
 
 export function useAddSchedule() {
-  return useMutation((data: ISchedule) => httpClient.post('schedules', data));
+  const queryClient = useQueryClient();
+
+  return useMutation((data: ISchedule) => httpClient.post('schedules', data), {
+    onSuccess: () => {
+      queryClient.invalidateQueries(['schedules']);
+    },
+  });
 }
 
 export function useDeleteScheduleById() {
-  return useMutation((id: number) => httpClient.delete(`schedules/${id}`));
+  const queryClient = useQueryClient();
+
+  return useMutation((id: number) => httpClient.delete(`schedules/${id}`), {
+    onSuccess: () => {
+      queryClient.invalidateQueries(['schedules']);
+    },
+  });
 }

--- a/src/queries/schedule.ts
+++ b/src/queries/schedule.ts
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ISchedule, ServerSideScheduleWrapper } from '../types';
 
 export function useGetSchedules() {
-  const query = '';
+  const query = '?_sort=start&_order=asc';
   return useQuery(
     ['schedules'],
     () => httpClient.get<ServerSideScheduleWrapper>(`schedules${query}`),


### PR DESCRIPTION
# 개요
post, delete 요청 후 업데이트 된 데이터 가져오기


# 내용
post, delete 요청 후 업데이트 된 데이터가 안가져와지는 현상을 수정.

package.json 스크립트에서 서버 실행하는 부분을 따로 실행해야해서 뺐습니다.